### PR TITLE
feat: show progress bar while fetching marks

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -370,7 +370,7 @@ async def doing_the_work(
     )
     message = await context.bot.send_message(
         user_id,
-        f"⏳ يتم جلب المعلومات من الموقع ...\n\n0 / {len(numbers)}  [▫️▫️▫️▫️▫️▫️▫️▫️▫️▫️]",
+        f"⏳ يتم جلب المعلومات من الموقع ...\n\n0 / {len(numbers)}\n  [▫️▫️▫️▫️▫️▫️▫️▫️▫️▫️]",
         reply_to_message_id=user_msg_id,
         reply_markup=keyboard,
     )

--- a/source/main.py
+++ b/source/main.py
@@ -370,12 +370,12 @@ async def doing_the_work(
     )
     message = await context.bot.send_message(
         user_id,
-        "⏳ يتم جلب المعلومات من الموقع ...",
+        f"⏳ يتم جلب المعلومات من الموقع ...\n\n0 / {len(numbers)}  [▫️▫️▫️▫️▫️▫️▫️▫️▫️▫️]",
         reply_to_message_id=user_msg_id,
         reply_markup=keyboard,
     )
     try:
-        gathered_results = await multi_async_request(numbers, recurse_limit)
+        gathered_results = await multi_async_request(numbers, recurse_limit, message)
         students_data = [extract_data(x) for x in gathered_results]
 
         if len(numbers) <= 5 and not html_bl:

--- a/source/web_scrapper.py
+++ b/source/web_scrapper.py
@@ -1,8 +1,10 @@
 import asyncio
 from dataclasses import dataclass
+from time import time
 from typing import List
 
 import aiohttp
+from telegram import Message
 
 UNIVERSITY_URL = "https://exam.homs-univ.edu.sy/exam-it/re.php"
 
@@ -14,14 +16,28 @@ class WebStudentResponse:
 
 
 async def multi_async_request(
-    numbers: List[int], recurse_limit: int = 2
+    numbers: List[int], recurse_limit: int = 2, message: Message = None
 ) -> List[WebStudentResponse]:
     async with aiohttp.ClientSession() as session:
-        tasks = [
-            asyncio.create_task(one_req(int(number), session, recurse_limit))
-            for number in numbers
-        ]
-        gathered = await asyncio.gather(*tasks)
+        requested_cnt = len(numbers)
+        gathered_cnt = 0 
+        gathered: List[WebStudentResponse] = []
+        message_last_update = time()
+        progress_bar = "▫️▫️▫️▫️▫️▫️▫️▫️▫️▫️"
+        progress_bar_end = 0
+        for number in numbers:
+            result  = await one_req(int(number), session, recurse_limit)
+            gathered.append(result)
+            gathered_cnt = gathered_cnt + 1
+            if message and time() - message_last_update >= 1:
+                while progress_bar_end < 10 and gathered_cnt / requested_cnt * 10 >= progress_bar_end + 1:
+                    progress_bar = progress_bar[:progress_bar_end * 2] + '◾️' + progress_bar[(progress_bar_end + 1) * 2:]
+                    progress_bar_end = progress_bar_end +1
+                await message.edit_text(
+                    f"⏳ يتم جلب المعلومات من الموقع ...\n\n{gathered_cnt} / {requested_cnt}  [{progress_bar}]",
+                    reply_markup=message.reply_markup
+                )
+                message_last_update = time()
     return gathered
 
 

--- a/source/web_scrapper.py
+++ b/source/web_scrapper.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import dataclass
-from time import time
+from time import monotonic
 from typing import List
 
 import aiohttp
@@ -19,30 +19,31 @@ async def multi_async_request(
     numbers: List[int], recurse_limit: int = 2, message: Message = None
 ) -> List[WebStudentResponse]:
     async with aiohttp.ClientSession() as session:
-        requested_cnt = len(numbers)
-        gathered_cnt = 0 
-        gathered: List[WebStudentResponse] = []
-        message_last_update = time()
-        progress_bar = "▫️▫️▫️▫️▫️▫️▫️▫️▫️▫️"
-        progress_bar_end = 0
-        for number in numbers:
-            result  = await one_req(int(number), session, recurse_limit)
-            gathered.append(result)
-            gathered_cnt = gathered_cnt + 1
-            if message and time() - message_last_update >= 1:
-                while progress_bar_end < 10 and gathered_cnt / requested_cnt * 10 >= progress_bar_end + 1:
-                    progress_bar = progress_bar[:progress_bar_end * 2] + '◾️' + progress_bar[(progress_bar_end + 1) * 2:]
-                    progress_bar_end = progress_bar_end +1
-                await message.edit_text(
-                    f"⏳ يتم جلب المعلومات من الموقع ...\n\n{gathered_cnt} / {requested_cnt}  [{progress_bar}]",
-                    reply_markup=message.reply_markup
+        processed = [0]
+        total = [len(numbers)]
+        current_time = [monotonic()]
+        tasks =[
+            asyncio.create_task(
+                one_req(
+                        int(number),
+                        session,
+                        recurse_limit,
+                        update_progress_bar_message,
+                        processed,
+                        total,
+                        message,
+                        current_time
+                    )
                 )
-                message_last_update = time()
+            for number in numbers
+        ]
+        gathered = await asyncio.gather(*tasks)
     return gathered
 
 
 async def one_req(
-    number, session: aiohttp.ClientSession, recurse_limit: int
+    number, session: aiohttp.ClientSession, recurse_limit: int,
+    callback = None, processed = None, total = None, message: Message = None, last_update = None 
 ) -> WebStudentResponse:
     if recurse_limit <= 0:
         raise Exception("uncompleted request, try again later")
@@ -53,7 +54,45 @@ async def one_req(
         if req.status != 200:
             await asyncio.sleep(1)
             return await one_req(number, session, recurse_limit - 1)
+        if callback:
+            processed[0] += 1
+            await callback(processed[0], total[0], message, last_update)
         return WebStudentResponse(number, res_data)
     except Exception:
         await asyncio.sleep(1)
         return await one_req(number, session, recurse_limit - 1)
+
+
+progress_bar_length = 10
+progress_bar_processed_icon = '◾️'
+progress_bar_unprocessed_icon = '️▫️'
+
+
+async def update_progress_bar_message(processed: int, total: int, message: Message, last_update: List[float]):
+    if monotonic() - last_update[0] >= 1:
+        last_update[0] = monotonic()
+        progress = await calculate_progress(processed, total, progress_bar_length)
+        progress_bar = await generate_progress_bar(progress, progress_bar_length) 
+        await message.edit_text(
+            reply_markup = message.reply_markup,
+            text = f"⏳ يتم جلب المعلومات من الموقع ...\n\n{processed} / {total}\n  [{progress_bar}]"
+        )
+ 
+ 
+async def calculate_progress(processed: int, total: int, max_progress_value: int) -> int:
+    if total < 0:
+        raise Exception("Can't calculate progress for nigative number of processes!")
+    if total == 0:
+        return max_progress_value
+    return int(processed / total * max_progress_value) 
+
+
+async def generate_progress_bar(progress: int, max_progress_value: int) -> str:
+    if progress < 0 or progress > max_progress_value:
+        raise Exception("Can't generate progress bar for invalid progress value!")
+    progress_bar = ''
+    for i in range(1,progress + 1):
+        progress_bar = progress_bar + progress_bar_processed_icon
+    for i in range(progress + 1, max_progress_value + 1):
+        progress_bar = progress_bar + progress_bar_unprocessed_icon
+    return progress_bar


### PR DESCRIPTION
#### New feature
- Add a progress bar that updates as marks are fetched.
- Display the number of students processed out of the total.
#### Reason for adding this feature
Fetching marks from the website could take a long time and users don't see any indication of progress. This may lead to the impression that the process is stuck.
#### Closes
Closes #5